### PR TITLE
Fix policy name uniqueness

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,14 @@ After `terraform apply` you have to go to the AWS Console SecretsManager dashboa
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.30.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.30.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.5.0 |
 
 ## Modules
 
@@ -61,6 +63,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_iam_policy.secrets_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [random_id.secrets_access_policy_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [aws_iam_role_policy_attachment.secret_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_secretsmanager_secret.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_iam_policy_document.secrets_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/main.tf
+++ b/main.tf
@@ -22,8 +22,12 @@ resource "aws_secretsmanager_secret" "default" {
   policy = data.aws_iam_policy_document.secrets_policy.json
 }
 
+resource "random_id" "secrets_access_policy_suffix" {
+  byte_length = 8
+}
+
 resource aws_iam_policy secrets_access {
-  name        = "secrets_access"
+  name        = "secrets_access_${random_id.secrets_access_policy_suffix.hex}"
   description = "Access rights to SecretsManager Secret created by terraform-aws-ecs-secrets-manager module"
 
   policy = <<-POLICY

--- a/versions.tf
+++ b/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 3.30.0"
     }
+    random = {
+      source = "hashicorp/random"
+      version = ">= 3.5.0"
+    }
   }
 }


### PR DESCRIPTION
### Issue
While using this module in the same AWS account more than once, an error appears that the policy name needs to be unique.

<img width="1206" alt="image" src="https://github.com/Exlabs/terraform-aws-ecs-secrets-manager/assets/2733755/106fc68f-22ee-4b98-816e-c19e9c249034">

### Solution
Using `random` provider I added a possibility to generate unique tokens stored in the terraform state that can be applied to policy names.