### PR TITLE
Add ability to get the whole secret as a key-value pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ This module uses the recommended way of passing sensitive data from SecretManage
 
 ## Usage
 
+### Passing specific keys to ECS task definition
 ```hcl
 module "secrets" {
   source  = "exlabs/ecs-secrets-manager/aws"
   # We recommend pinning every module to a specific version
-  version = "1.0.0"
+  version = "1.1.0"
   name    = "data-pipeline-secrets"
 
   ecs_task_execution_roles = [
@@ -22,6 +23,39 @@ module "secrets" {
     "STRIPE_PUBLIC_KEY",
     "STRIPE_SECRET_KEY",
     "STRIPE_WEBHOOK_SECRET"
+  ]
+}
+
+resource "aws_ecs_task_definition" "data_pipeline" {
+  #...
+
+  container_definitions = jsonencode([
+    {
+      secrets = module.secrets.ecs_secrets,
+      #...
+    }
+  ])
+}
+```
+
+### Passing the whole AWS Secret Manager secret to the ECS task as a single variable
+```hcl
+module "secrets" {
+  source  = "exlabs/ecs-secrets-manager/aws"
+  # We recommend pinning every module to a specific version
+  version = "1.1.0"
+  name    = "data-pipeline-secrets"
+
+  enable_secret_assigned_to_single_key = true
+
+  ecs_task_execution_roles = [
+    "ecs-task-execution-role1",
+    "ecs-task-execution-role2"
+  ]
+
+  # You can define your own key or leave it default then the key name is built based on the secret name
+  key_names = [
+    "YOUR_OWN_KEY"
   ]
 }
 
@@ -77,10 +111,12 @@ No modules.
 | <a name="input_key_names"></a> [key\_names](#input\_key\_names) | Secret names that will be injected as env variables | `list(string)` | `[]` | yes |
 | <a name="input_name"></a> [name](#input\_name) | AWS SecretsManager secret name | `string` | n/a | yes |
 | <a name="input_description"></a> [description](#input\_description) | AWS SecretsManager secret description | `string` | n/a | no |
+| <a name="input_enable_secret_assigned_to_single_key"></a> [enable\_secret\_assigned\_to\_single\_key](#input\_enable\_secret\_assigned\_to\_single\_key) | Enables returning the whole secret as a single key-value pair | `string` | `false` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | <a name="output_ecs_secrets"></a> [ecs\_secrets](#output\_ecs\_secrets) | Secrets description to be injected in the ECS Container definition. |
+| <a name="output_secretsmanager_secret_arn"></a> [secretsmanager\_secret\_arn](#output\_secretsmanager\_secret\_arn) | AWS SecretsManager secret ARN |
 <!-- END_TF_DOCS -->

--- a/main.tf
+++ b/main.tf
@@ -34,9 +34,14 @@ resource "aws_iam_role_policy_attachment" "this" {
 }
 
 locals {
-  ecs_secrets = [
+  ecs_secrets = var.enable_secret_assigned_to_single_key ? [
+    {
+      name      = coalesce(one(var.key_names), upper(replace(replace(var.name,"/[^a-zA-Z\\d\\-_:]/","*"),"-","_")))
+      valueFrom = aws_secretsmanager_secret.this.arn
+    }
+  ] : [
     for key_name in var.key_names :{
-      name = key_name
+      name      = key_name
       valueFrom = "${aws_secretsmanager_secret.this.arn}:${key_name}::"
     }
   ]

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,3 +2,8 @@ output "ecs_secrets" {
   value = local.ecs_secrets
   description = "Secrets description to be injected in the ECS Container definition."
 }
+
+output "secretsmanager_secret_arn" {
+  value = aws_secretsmanager_secret.this.arn
+  description = "AWS SecretsManager secret ARN"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -23,3 +23,10 @@ variable "key_names" {
   nullable    = false
   default     = []
 }
+
+variable "enable_secret_assigned_to_single_key" {
+  description = "Enables returning the whole secret as a single key-value pair"
+  type        = bool
+  nullable    = false
+  default     = false
+}


### PR DESCRIPTION
## Context
There is a need to create a secret and pass the whole secret to the ECS task definition as a single ENV.

## Changes
- added new attribute `enable_secret_assigned_to_single_key` that changes the default behaviour
- added possibility to get secret ARN as an output